### PR TITLE
Add support for presets

### DIFF
--- a/common.h
+++ b/common.h
@@ -4,8 +4,9 @@ namespace esphome {
 namespace xiaomi {
 namespace bslamp2 {
 
+// Used for logging purposes.
 static const char *TAG = "xiaomi_bslamp2";
-    
+
 } // namespace bslamp2
 } // namespace xiaomi
 } // namespace esphome

--- a/doc/FLASHING.md
+++ b/doc/FLASHING.md
@@ -138,9 +138,9 @@ reconnect the power to boot into the restored firmware.
 
 ## Flash new firmware
 
-Setup an ESPHome Project, see [README.md](../README.md)
-Compile the firmware for the device and download the `firmware.bin` file
-to the device to which the serial adapter is connected.
+Setup an ESPHome Project (see [README.md](../README.md)),compile the firmware
+for the device and download the `firmware.bin` file to the device to which
+the serial adapter is connected.
 
 You can flash the device using esphome or esptool.
 I normally use the [esphome-flasher](https://github.com/esphome/esphome-flasher)
@@ -187,5 +187,3 @@ https://github.com/arendst/Tasmota/tree/firmware/firmware/tasmota32/ESP32_needed
 
 (remember that the [esphome-flasher](https://github.com/esphome/esphome-flasher)
 will give you a bit less of a hard-core experience during flashing)
-
-

--- a/doc/example.yaml
+++ b/doc/example.yaml
@@ -96,16 +96,16 @@ light:
           update_interval: 3s
     presets:
       - rgb:
-          - red_bright:  { red: 1 }
-          - green:       { green: 1 }
-          - blue_dimmed: { blue: 1 }
-          - yellow:      { red: 1, green: 1 }
-          - something:   { red: 0.2, green: 0.4, blue: 1 }
+          - red_bright:  { red: 100% }
+          - green:       { green: 100% }
+          - blue_dimmed: { blue: 100% }
+          - yellow:      { red: 100%, green: 100% }
+          - purple:      { red: 100%, blue: 100% }
       - white:
-          - warm:        { color_temperature: 588 }
-          - luke:        { color_temperature: 400 }
-          - chilly:      { color_temperature: 275 }
           - cold:        { color_temperature: 153 }
+          - chilly:      { color_temperature: 275 }
+          - luke:        { color_temperature: 400 }
+          - warm:        { color_temperature: 587 }
 
 # This text sensor propagates the currently active light mode.
 # The possible light modes are: "off", "rgb", "white" and "night".
@@ -151,13 +151,17 @@ binary_sensor:
   - platform: xiaomi_bslamp2
     id: ${id_color_button}
     part: color button
-    on_press:
-      then:
-        - light.turn_on:
-            id: ${id_light}
-            red: !lambda return random_float();
-            green: !lambda return random_float();
-            blue: !lambda return random_float();
+    on_multi_click:
+      - timing:
+          - ON for at most 0.6s
+        then:
+          - preset.activate:
+              next: preset
+      - timing:
+          - ON for at least 0.6s
+        then:
+          - preset.activate:
+              next: group
 
 # This sensor component publishes touch events for the front panel slider.
 # The published value represents the level at which the slider was touched.

--- a/doc/example.yaml
+++ b/doc/example.yaml
@@ -94,6 +94,18 @@ light:
           name: "Fast Random"
           transition_length: 3s
           update_interval: 3s
+    presets:
+      - rgb:
+          - red_bright:  { red: 1 }
+          - green:       { green: 1 }
+          - blue_dimmed: { blue: 1 }
+          - yellow:      { red: 1, green: 1 }
+          - something:   { red: 0.2, green: 0.4, blue: 1 }
+      - white:
+          - warm:        { color_temperature: 588 }
+          - luke:        { color_temperature: 400 }
+          - chilly:      { color_temperature: 275 }
+          - cold:        { color_temperature: 153 }
 
 # This text sensor propagates the currently active light mode.
 # The possible light modes are: "off", "rgb", "white" and "night".

--- a/doc/example.yaml
+++ b/doc/example.yaml
@@ -94,18 +94,26 @@ light:
           name: "Fast Random"
           transition_length: 3s
           update_interval: 3s
+    # You can define one or more groups of presets. These presets can
+    # be activated using various "preset.activate" action options.
+    # The presets can for example be used to mimic the behavior of the
+    # original firmware (tapping the color button = go to next preset,
+    # holding the color button = switch between RGB and white light mode).
+    # These bindings have been setup below, using the binary_sensor for
+    # the color button.
     presets:
-      - rgb:
-          - red_bright:  { red: 100% }
-          - green:       { green: 100% }
-          - blue_dimmed: { blue: 100% }
-          - yellow:      { red: 100%, green: 100% }
-          - purple:      { red: 100%, blue: 100% }
-      - white:
-          - cold:        { color_temperature: 153 }
-          - chilly:      { color_temperature: 275 }
-          - luke:        { color_temperature: 400 }
-          - warm:        { color_temperature: 587 }
+      rgb:
+        red:         { red: 100%, green: 0%,   blue: 0%   }
+        green:       { red: 0%,   green: 100%, blue: 0%   }
+        blue:        { red: 0%,   green: 0%,   blue: 100% }
+        yellow:      { red: 100%, green: 100%, blue: 0%   }
+        purple:      { red: 100%, green: 0%,   blue: 100% }
+        randomize:   { effect: Fast Random                }
+      white:
+        cold:        { color_temperature: 153 mireds      }
+        chilly:      { color_temperature: 275 mireds      }
+        luke:        { color_temperature: 400 mireds      }
+        warm:        { color_temperature: 588 mireds      }
 
 # This text sensor propagates the currently active light mode.
 # The possible light modes are: "off", "rgb", "white" and "night".
@@ -147,7 +155,8 @@ binary_sensor:
             blue: 1
             brightness: 0.01
 
-  # When touching the color button, set a random color.
+  # When touching the color button, acivate the next preset.
+  # When holding the color button, activate the next preset group.
   - platform: xiaomi_bslamp2
     id: ${id_color_button}
     part: color button

--- a/front_panel_hal.h
+++ b/front_panel_hal.h
@@ -185,8 +185,8 @@ public:
     }
 
     void dump_config() {
-        ESP_LOGCONFIG(TAG, "I2C interrupt");
-        LOG_PIN("  Interrupt pin: ", trigger_pin_);
+        ESP_LOGCONFIG(TAG, "FrontPanelHAL:");
+        LOG_PIN("  I2C interrupt pin: ", trigger_pin_);
     }
 
     void loop() {

--- a/light/__init__.py
+++ b/light/__init__.py
@@ -2,9 +2,10 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import light
 from esphome import automation
+from esphome.core import coroutine
 from esphome.const import (
-    CONF_RED, CONF_GREEN, CONF_BLUE, CONF_WHITE,
-    CONF_OUTPUT_ID, CONF_TRIGGER_ID, CONF_ID
+    CONF_RED, CONF_GREEN, CONF_BLUE, CONF_WHITE, CONF_COLOR_TEMPERATURE,
+    CONF_OUTPUT_ID, CONF_TRIGGER_ID, CONF_ID,
 )
 from .. import bslamp2_ns, CODEOWNERS, CONF_LIGHT_HAL_ID, LightHAL
 
@@ -13,10 +14,37 @@ AUTO_LOAD = ["xiaomi_bslamp2"]
 CONF_MASTER1 = "master1"
 CONF_MASTER2 = "master2"
 CONF_ON_BRIGHTNESS = "on_brightness"
+CONF_PRESETS_ID = "presets_id"
+CONF_PRESETS = "presets"
 
+# Classes.
 XiaomiBslamp2LightState = bslamp2_ns.class_("XiaomiBslamp2LightState", light.LightState)
 XiaomiBslamp2LightOutput = bslamp2_ns.class_("XiaomiBslamp2LightOutput", light.LightOutput)
+PresetsContainer = bslamp2_ns.class_("PresetsContainer", cg.Component)
+
+# Trigger.
 BrightnessTrigger = bslamp2_ns.class_("BrightnessTrigger", automation.Trigger.template())
+
+# Actions.
+#ActivatePresetGroup = bslamp2_ns.class_("ActivatePresetGroup", automation.Action)
+#ActivatePreset = bslamp2_ns.class_("ActivatePreset", automation.Action)
+#NextPresetGroup = bslamp2_ns.class_("NextPresetAction", automation.Action)
+#NextPreset = bslamp2_ns.class_("NextPresetAction", automation.Action)
+
+PRESETS_SCHEMA = cv.Schema({
+    str: cv.Schema({
+        str: cv.Any(
+            cv.Schema({
+                cv.Optional(CONF_RED, default=0): cv.percentage,
+                cv.Optional(CONF_GREEN, default=0): cv.percentage,
+                cv.Optional(CONF_BLUE, default=0): cv.percentage,
+            }),
+            cv.Schema({
+                cv.Required(CONF_COLOR_TEMPERATURE): cv.int_range(min=153, max=588),
+            }),
+        )
+    })
+})
 
 CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
     {
@@ -28,16 +56,46 @@ CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(BrightnessTrigger),
             }
         ),
+        cv.GenerateID(CONF_PRESETS_ID): cv.declare_id(PresetsContainer),
+        cv.Optional(CONF_PRESETS): PRESETS_SCHEMA,
     }
 )
 
-def to_code(config):
-    var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
-    yield light.register_light(var, config)
+#automation.register_action("preset.activate_group", ActivatePresetGroup, cv.string)
+#def activate_group_to_code(config, action_id, template_arg, args):
+#    presets_var = yield cg.get_variable(config[CONF_PRESETS_ID]) 
+#    cg.add(presets_var.activate_group(...));
 
+@coroutine
+def light_output_to_code(config):
+    light_output_var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+    yield light.register_light(light_output_var, config)
     light_hal_var = yield cg.get_variable(config[CONF_LIGHT_HAL_ID])
-    cg.add(var.set_parent(light_hal_var))
+    cg.add(light_output_var.set_parent(light_hal_var))
 
+@coroutine
+def on_brightness_to_code(config):
+    light_output_var = yield cg.get_variable(config[CONF_OUTPUT_ID])
     for conf in config.get(CONF_ON_BRIGHTNESS, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], light_output_var)
         yield automation.build_automation(trigger, [(float, "x")], conf)
+
+@coroutine
+def presets_to_code(config):
+    light_state_var = yield cg.get_variable(config[CONF_ID])
+    presets_var = cg.new_Pvariable(config[CONF_PRESETS_ID], light_state_var)
+    yield cg.register_component(presets_var, config)
+
+    for preset_group, presets in config.get(CONF_PRESETS, {}).items():
+        for name, preset in presets.items():
+            if CONF_COLOR_TEMPERATURE in preset:
+                cg.add(presets_var.add(
+                    preset_group, name, preset[CONF_COLOR_TEMPERATURE]))
+            else:
+                cg.add(presets_var.add(
+                    preset_group, name, preset[CONF_RED], preset[CONF_GREEN], preset[CONF_BLUE]))
+
+def to_code(config):
+    yield light_output_to_code(config)
+    yield on_brightness_to_code(config)
+    yield presets_to_code(config)

--- a/light/__init__.py
+++ b/light/__init__.py
@@ -6,6 +6,7 @@ from esphome.core import coroutine
 from esphome.const import (
     CONF_RED, CONF_GREEN, CONF_BLUE, CONF_WHITE, CONF_COLOR_TEMPERATURE,
     CONF_OUTPUT_ID, CONF_TRIGGER_ID, CONF_ID,
+    CONF_TRANSITION_LENGTH, CONF_BRIGHTNESS, CONF_EFFECT
 )
 from .. import bslamp2_ns, CODEOWNERS, CONF_LIGHT_HAL_ID, LightHAL
 
@@ -14,6 +15,7 @@ AUTO_LOAD = ["xiaomi_bslamp2"]
 CONF_MASTER1 = "master1"
 CONF_MASTER2 = "master2"
 CONF_ON_BRIGHTNESS = "on_brightness"
+CONF_PRESET_ID = "preset_id"
 CONF_PRESETS_ID = "presets_id"
 CONF_PRESETS = "presets"
 CONF_NEXT = "next"
@@ -23,27 +25,44 @@ CONF_PRESET = "preset"
 XiaomiBslamp2LightState = bslamp2_ns.class_("XiaomiBslamp2LightState", light.LightState)
 XiaomiBslamp2LightOutput = bslamp2_ns.class_("XiaomiBslamp2LightOutput", light.LightOutput)
 PresetsContainer = bslamp2_ns.class_("PresetsContainer", cg.Component)
+Preset = bslamp2_ns.class_("Preset", cg.Component)
 BrightnessTrigger = bslamp2_ns.class_("BrightnessTrigger", automation.Trigger.template())
 ActivatePresetAction = bslamp2_ns.class_("ActivatePresetAction", automation.Action)
 
 PRESETS_SCHEMA = cv.Schema({
     str.lower: cv.Schema({
-        str.lower: cv.Any(
-            cv.Schema({
-                cv.Optional(CONF_RED, default=0): cv.percentage,
-                cv.Optional(CONF_GREEN, default=0): cv.percentage,
-                cv.Optional(CONF_BLUE, default=0): cv.percentage,
-            }),
-            cv.Schema({
-                cv.Required(CONF_COLOR_TEMPERATURE): cv.int_range(min=153, max=588),
-            }),
-        )
+        str.lower: light.automation.LIGHT_TURN_ON_ACTION_SCHEMA
     })
 })
 
+PRESET_SCHEMA_BASE = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.use_id(XiaomiBslamp2LightState),
+        cv.GenerateID(CONF_PRESET_ID): cv.declare_id(Preset),
+    }
+)
+
+PRESET_SCHEMA = cv.Any(
+    PRESET_SCHEMA_BASE.extend({
+        cv.Required(CONF_EFFECT): cv.string
+    }),
+    PRESET_SCHEMA_BASE.extend({
+        cv.Required(CONF_COLOR_TEMPERATURE): cv.color_temperature,
+        cv.Optional(CONF_BRIGHTNESS): cv.percentage,
+        cv.Optional(CONF_TRANSITION_LENGTH): cv.positive_time_period_milliseconds,
+    }),
+    PRESET_SCHEMA_BASE.extend({
+        cv.Required(CONF_RED): cv.percentage,
+        cv.Required(CONF_GREEN): cv.percentage,
+        cv.Required(CONF_BLUE): cv.percentage,
+        cv.Optional(CONF_BRIGHTNESS): cv.percentage,
+        cv.Optional(CONF_TRANSITION_LENGTH): cv.positive_time_period_milliseconds,
+    }),
+)
+
 CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
     {
-        cv.GenerateID(): cv.declare_id(XiaomiBslamp2LightState),
+        cv.GenerateID(CONF_ID): cv.declare_id(XiaomiBslamp2LightState),
         cv.GenerateID(CONF_LIGHT_HAL_ID): cv.use_id(LightHAL),
         cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(XiaomiBslamp2LightOutput),
         cv.Optional(CONF_ON_BRIGHTNESS): automation.validate_automation(
@@ -52,7 +71,11 @@ CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
             }
         ),
         cv.GenerateID(CONF_PRESETS_ID): cv.declare_id(PresetsContainer),
-        cv.Optional(CONF_PRESETS): PRESETS_SCHEMA,
+        cv.Optional(CONF_PRESETS): cv.Schema({
+            str.lower: cv.Schema({
+                str.lower: PRESET_SCHEMA
+            })
+        }),
     }
 )
 
@@ -128,19 +151,37 @@ def on_brightness_to_code(config):
         yield automation.build_automation(trigger, [(float, "x")], conf)
 
 @coroutine
+def preset_to_code(config, preset_group, preset_name):
+    light_var = yield cg.get_variable(config[CONF_ID])
+    preset_var = cg.new_Pvariable(
+        config[CONF_PRESET_ID], light_var, preset_group, preset_name)
+    if CONF_TRANSITION_LENGTH in config:
+        cg.add(preset_var.set_transition_length(config[CONF_TRANSITION_LENGTH]))
+    if CONF_BRIGHTNESS in config:
+        cg.add(preset_var.set_brightness(config[CONF_BRIGHTNESS]))
+    if CONF_RED in config:
+        cg.add(preset_var.set_red(config[CONF_RED]))
+    if CONF_GREEN in config:
+        cg.add(preset_var.set_green(config[CONF_GREEN]))
+    if CONF_BLUE in config:
+        cg.add(preset_var.set_blue(config[CONF_BLUE]))
+    if CONF_COLOR_TEMPERATURE in config:
+        cg.add(preset_var.set_color_temperature(config[CONF_COLOR_TEMPERATURE]))
+    if CONF_EFFECT in config:
+        cg.add(preset_var.set_effect(config[CONF_EFFECT]))
+    else:
+        cg.add(preset_var.set_effect("None"))
+    yield cg.register_component(preset_var, config)
+
+@coroutine
 def presets_to_code(config):
-    light_state_var = yield cg.get_variable(config[CONF_ID])
-    presets_var = cg.new_Pvariable(config[CONF_PRESETS_ID], light_state_var)
+    presets_var = cg.new_Pvariable(config[CONF_PRESETS_ID])
     yield cg.register_component(presets_var, config)
 
     for preset_group, presets in config.get(CONF_PRESETS, {}).items():
-        for name, preset in presets.items():
-            if CONF_COLOR_TEMPERATURE in preset:
-                cg.add(presets_var.add(
-                    preset_group, name, preset[CONF_COLOR_TEMPERATURE]))
-            else:
-                cg.add(presets_var.add(
-                    preset_group, name, preset[CONF_RED], preset[CONF_GREEN], preset[CONF_BLUE]))
+        for preset_name, preset_config in presets.items():
+            preset = yield preset_to_code(preset_config, preset_group, preset_name)
+            cg.add(presets_var.add_preset(preset))
 
 def to_code(config):
     yield light_output_to_code(config)

--- a/light/automation.h
+++ b/light/automation.h
@@ -39,8 +39,19 @@ public:
 
     void play(Ts... x) override { 
         auto operation = this->operation_.value(x...);
-        auto group = this->group_.optional_value(x...);
-        auto preset = this->preset_.optional_value(x...);
+
+        if (operation == "next_group") {
+            presets_->activate_next_group();
+        } else if (operation == "next_preset") {
+            presets_->activate_next_preset();
+        } else if (operation == "activate_group") {
+            auto group = this->group_.value(x...);
+            presets_->activate_group(group);
+        } else if (operation == "activate_preset") {
+            auto group = this->group_.value(x...);
+            auto preset = this->preset_.value(x...);
+            presets_->activate_preset(group, preset);
+        }
     }
 
 protected:

--- a/light/automation.h
+++ b/light/automation.h
@@ -4,6 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
 #include "light_output.h"
+#include "presets.h"
 
 namespace esphome {
 namespace xiaomi {
@@ -26,6 +27,24 @@ public:
     }
 protected:
     float last_brightness_ = -1.0f;
+};
+
+template<typename... Ts> class ActivatePresetAction : public Action<Ts...> {
+public:
+    explicit ActivatePresetAction(PresetsContainer *presets) : presets_(presets) {}
+
+    TEMPLATABLE_VALUE(std::string, operation);
+    TEMPLATABLE_VALUE(std::string, group);
+    TEMPLATABLE_VALUE(std::string, preset);
+
+    void play(Ts... x) override { 
+        auto operation = this->operation_.value(x...);
+        auto group = this->group_.optional_value(x...);
+        auto preset = this->preset_.optional_value(x...);
+    }
+
+protected:
+    PresetsContainer *presets_;
 };
 
 } // namespace bslamp2

--- a/light/color_night_light.h
+++ b/light/color_night_light.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../common.h"
+#include "light_modes.h" 
 #include "gpio_outputs.h"
 
 namespace esphome {

--- a/light/color_off.h
+++ b/light/color_off.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <array>
-#include <stdexcept>
-
 #include "../common.h"
+#include "light_modes.h" 
 #include "gpio_outputs.h"
 
 namespace esphome {

--- a/light/color_rgb_light.h
+++ b/light/color_rgb_light.h
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "../common.h"
+#include "light_modes.h" 
 #include "gpio_outputs.h"
 
 namespace esphome {

--- a/light/color_white_light.h
+++ b/light/color_white_light.h
@@ -4,6 +4,7 @@
 #include <stdexcept>
 
 #include "../common.h"
+#include "light_modes.h" 
 #include "gpio_outputs.h"
 
 namespace esphome {

--- a/light/gpio_outputs.h
+++ b/light/gpio_outputs.h
@@ -1,15 +1,10 @@
 #pragma once 
 
+#include "light_modes.h"
+
 namespace esphome {
 namespace xiaomi {
 namespace bslamp2 {
-
-// Light modes that can be reported by implementations of GPIOOutputs.
-static const std::string LIGHT_MODE_UNKNOWN { "unknown" };
-static const std::string LIGHT_MODE_OFF { "off" };
-static const std::string LIGHT_MODE_RGB { "rgb" };
-static const std::string LIGHT_MODE_WHITE { "white" };
-static const std::string LIGHT_MODE_NIGHT { "night" };
 
 /**
  * This abstract class is used for implementing classes that translate

--- a/light/light_modes.h
+++ b/light/light_modes.h
@@ -1,0 +1,15 @@
+#pragma once 
+
+namespace esphome {
+namespace xiaomi {
+namespace bslamp2 {
+
+static const std::string LIGHT_MODE_UNKNOWN { "unknown" };
+static const std::string LIGHT_MODE_OFF { "off" };
+static const std::string LIGHT_MODE_RGB { "rgb" };
+static const std::string LIGHT_MODE_WHITE { "white" };
+static const std::string LIGHT_MODE_NIGHT { "night" };
+
+} // namespace bslamp2
+} // namespace xiaomi
+} // namespace esphome

--- a/light/light_output.h
+++ b/light/light_output.h
@@ -108,26 +108,6 @@ protected:
         transition_handler_ = new ColorTransitionHandler(exposer);
     }
 };
-
-/**
- * This custom LightState class is used to provide access to the protected
- * LightTranformer information in the LightState class.
- *
- * This class is used by the ColorTransitionHandler class to inspect if
- * an ongoing light color transition is active in a LightState object.
- */
-class XiaomiBslamp2LightState : public light::LightState, public LightStateTransformerInspector
-{
-public:
-    XiaomiBslamp2LightState(const std::string &name, XiaomiBslamp2LightOutput *output) : light::LightState(name, output) {
-        output->set_transformer_inspector(this);
-    }
-
-    bool is_active() { return transformer_ != nullptr; }
-    bool is_transition() { return transformer_->is_transition(); }
-    light::LightColorValues get_end_values() { return transformer_->get_end_values(); }
-    float get_progress() { return transformer_->get_progress(); }
-};
     
 } // namespace bslamp2
 } // namespace xiaomi

--- a/light/light_state.h
+++ b/light/light_state.h
@@ -1,0 +1,31 @@
+#pragma once 
+
+#include "../common.h"
+
+namespace esphome {
+namespace xiaomi {
+namespace bslamp2 {
+
+/**
+ * This custom LightState class is used to provide access to the protected
+ * LightTranformer information in the LightState class.
+ *
+ * This class is used by the ColorTransitionHandler class to inspect if
+ * an ongoing light color transition is active in the LightState object.
+ */
+class XiaomiBslamp2LightState : public light::LightState, public LightStateTransformerInspector
+{
+public:
+    XiaomiBslamp2LightState(const std::string &name, XiaomiBslamp2LightOutput *output) : light::LightState(name, output) {
+        output->set_transformer_inspector(this);
+    }
+
+    bool is_active() { return transformer_ != nullptr; }
+    bool is_transition() { return transformer_->is_transition(); }
+    light::LightColorValues get_end_values() { return transformer_->get_end_values(); }
+    float get_progress() { return transformer_->get_progress(); }
+};
+    
+} // namespace bslamp2
+} // namespace xiaomi
+} // namespace esphome

--- a/light/presets.h
+++ b/light/presets.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <map>
+#include <vector>
+#include "../common.h"
+
+namespace esphome {
+namespace xiaomi {
+namespace bslamp2 {
+
+using Order = std::vector<std::string>;
+using Presets = std::map<std::string, light::LightCall *>;
+using PresetOrder = std::map<std::string, Order>;
+using PresetGroups = std::map<std::string, Presets>;
+using PresetGroupOrder = Order;
+
+class PresetsContainer : public Component {
+public:
+    explicit PresetsContainer(light::LightState *light) : _light(light) { }
+
+    void dump_config() {
+        if (map_.empty()) {
+            return;
+        }
+        ESP_LOGCONFIG(TAG, "Light Presets:");
+        for (auto group : group_order_) {
+            ESP_LOGCONFIG(TAG, "  Preset group: %s", group.c_str());
+            for (auto name : preset_order_[group]) {
+                ESP_LOGCONFIG(TAG, "    Preset: %s", name.c_str());
+            }
+        }
+    }
+
+    void add(std::string group, std::string name, float red, float green, float blue) {
+        auto call = make_preset_slot_(group, name);
+        call->set_red(red);
+        call->set_green(green);
+        call->set_blue(blue);
+    }
+
+    void add(std::string group, std::string name, float color_temperature) {
+        auto call = make_preset_slot_(group, name);
+        call->set_color_temperature(color_temperature);
+    }
+
+protected:
+    light::LightState *_light;
+    PresetGroups map_;
+    PresetGroupOrder group_order_;
+    PresetOrder preset_order_;
+
+    light::LightCall *make_preset_slot_(std::string group, std::string name) {
+        // Check if the group already exists. If not, then create it.
+        if (map_.find(group) == map_.end()) {
+            map_[group] = Presets();
+            group_order_.push_back(group);
+            preset_order_[group] = Order();
+        }
+        if (map_[group].find(name) == map_[group].end()) {
+            map_[group][name] = new light::LightCall(_light);
+            preset_order_[group].push_back(name);
+        }
+
+        return map_[group][name];
+    }
+};
+
+} // namespace bslamp2
+} // namespace xiaomi
+} // namespace esphome

--- a/light/presets.h
+++ b/light/presets.h
@@ -2,8 +2,6 @@
 
 #include "../common.h"
 #include "esphome/core/optional.h"
-#include <functional>
-#include <vector>
 
 namespace esphome {
 namespace xiaomi {
@@ -87,7 +85,6 @@ public:
 
     Preset *get_preset(std::string p_name) {
         for (auto p = first_preset; p != nullptr; p = p->next_preset) {
-            ESP_LOGE(TAG, "CHECK '%s' vs '%s'", p_name.c_str(), p->name.c_str());
             if (p->name == p_name) {
                 return p;
             }

--- a/light/presets.h
+++ b/light/presets.h
@@ -94,7 +94,8 @@ public:
         active_group_ = active_group_->next_group == nullptr
             ? first_group_ : active_group_->next_group;
         if (active_group_->active_preset == nullptr) {
-            ESP_LOGW(TAG, "activate_next_group(): no presets defined for group %s", active_group_->name.c_str());
+            ESP_LOGW(TAG, "activate_next_group(): no presets defined for group %s",
+                active_group_->name.c_str());
             return;
         }
         ESP_LOGW(TAG, "activate_next_group(): activating %s/%s",
@@ -110,7 +111,8 @@ public:
         }
         auto p = active_group_->active_preset;
         if (p == nullptr) {
-            ESP_LOGW(TAG, "activate_next_preset(): no presets defined for group %s", active_group_->name.c_str());
+            ESP_LOGW(TAG, "activate_next_preset(): no presets defined for group %s",
+                active_group_->name.c_str());
             return;
         }
         active_group_->active_preset = p->next_preset == nullptr 

--- a/light/presets.h
+++ b/light/presets.h
@@ -1,67 +1,170 @@
 #pragma once
 
-#include <map>
-#include <vector>
 #include "../common.h"
 
 namespace esphome {
 namespace xiaomi {
 namespace bslamp2 {
 
-using Order = std::vector<std::string>;
-using Presets = std::map<std::string, light::LightCall *>;
-using PresetOrder = std::map<std::string, Order>;
-using PresetGroups = std::map<std::string, Presets>;
-using PresetGroupOrder = Order;
+class Preset {
+public:
+    std::string name;
+    Preset *next_preset = nullptr;
+    light::LightCall *light_call;
+
+    explicit Preset(std::string name) : name(name) {}
+
+    void set_light_call(light::LightCall *light_call) {
+        this->light_call = light_call;
+    }
+
+    void apply() {
+        light_call->perform();
+    }
+};
+
+class PresetGroup {
+public:
+    std::string name;
+    PresetGroup *next_group = nullptr;
+    Preset *first_preset = nullptr;
+    Preset *last_preset = nullptr;
+    Preset *active_preset = nullptr;
+
+    explicit PresetGroup(std::string g_name) : name(g_name) {}
+
+    Preset *make_preset(std::string p_name) {
+        auto p = get_preset(p_name);
+        if (p == nullptr) {
+            p = new Preset(p_name);
+            if (first_preset == nullptr) {
+                first_preset = last_preset = active_preset = p;
+            } else {
+                last_preset->next_preset = p;
+                last_preset = p;
+            }
+        }
+        return p;
+    }
+
+    Preset *get_preset(std::string p_name) {
+        for (auto p = first_preset; p != nullptr; p = p->next_preset) {
+            if (p->name == p_name) {
+                return p;
+            }
+        }
+        return nullptr;
+    }
+};
 
 class PresetsContainer : public Component {
 public:
     explicit PresetsContainer(light::LightState *light) : _light(light) { }
 
     void dump_config() {
-        if (map_.empty()) {
+        if (first_group_ == nullptr) {
             return;
         }
         ESP_LOGCONFIG(TAG, "Light Presets:");
-        for (auto group : group_order_) {
-            ESP_LOGCONFIG(TAG, "  Preset group: %s", group.c_str());
-            for (auto name : preset_order_[group]) {
-                ESP_LOGCONFIG(TAG, "    Preset: %s", name.c_str());
+        for (auto g = first_group_; g != nullptr; g = g->next_group) {
+            ESP_LOGCONFIG(TAG, "  Preset group: %s", g->name.c_str());
+            for (auto p = g->first_preset; p != nullptr; p = p->next_preset) {
+                ESP_LOGCONFIG(TAG, "    Preset: %s", p->name.c_str());
             }
         }
     }
 
-    void add(std::string group, std::string name, float red, float green, float blue) {
-        auto call = make_preset_slot_(group, name);
-        call->set_red(red);
-        call->set_green(green);
-        call->set_blue(blue);
+    void add(std::string g_name, std::string p_name, float r, float g, float b) {
+        auto call = make_preset_call_(g_name, p_name);
+        call->set_red(r);
+        call->set_green(g);
+        call->set_blue(b);
     }
 
-    void add(std::string group, std::string name, float color_temperature) {
-        auto call = make_preset_slot_(group, name);
-        call->set_color_temperature(color_temperature);
+    void add(std::string g_name, std::string p_name, float t) {
+        auto call = make_preset_call_(g_name, p_name);
+        call->set_color_temperature(t);
+    }
+
+    void activate_next_group() {
+        if (active_group_ == nullptr) {
+            ESP_LOGW(TAG, "activate_next_group(): no preset groups defined");
+            return;
+        }
+        active_group_ = active_group_->next_group == nullptr
+            ? first_group_ : active_group_->next_group;
+        if (active_group_->active_preset == nullptr) {
+            ESP_LOGW(TAG, "activate_next_group(): no presets defined for group %s", active_group_->name.c_str());
+            return;
+        }
+        ESP_LOGW(TAG, "activate_next_group(): activating %s/%s",
+            active_group_->name.c_str(),
+            active_group_->active_preset->name.c_str());
+        active_group_->active_preset->apply();
+    }
+
+    void activate_next_preset() {
+        if (active_group_ == nullptr) {
+            ESP_LOGW(TAG, "activate_next_preset(): no preset groups defined");
+            return;
+        }
+        auto p = active_group_->active_preset;
+        if (p == nullptr) {
+            ESP_LOGW(TAG, "activate_next_preset(): no presets defined for group %s", active_group_->name.c_str());
+            return;
+        }
+        active_group_->active_preset = p->next_preset == nullptr 
+            ? active_group_->first_preset : p->next_preset;
+        ESP_LOGW(TAG, "activate_next_preset(): activating %s/%s",
+            active_group_->name.c_str(),
+            active_group_->active_preset->name.c_str());
+        active_group_->active_preset->apply();
+    }
+
+    void activate_group(std::string g_name) {
+        ESP_LOGI(TAG, "Activate group %s", g_name.c_str());
+    }
+
+    void activate_preset(std::string g_name, std::string p_name) {
+        ESP_LOGI(TAG, "Activate preset %s/%s", g_name.c_str(), p_name.c_str());
     }
 
 protected:
     light::LightState *_light;
-    PresetGroups map_;
-    PresetGroupOrder group_order_;
-    PresetOrder preset_order_;
+    PresetGroup *first_group_ = nullptr;
+    PresetGroup *last_group_ = nullptr;
+    PresetGroup *active_group_ = nullptr;
 
-    light::LightCall *make_preset_slot_(std::string group, std::string name) {
-        // Check if the group already exists. If not, then create it.
-        if (map_.find(group) == map_.end()) {
-            map_[group] = Presets();
-            group_order_.push_back(group);
-            preset_order_[group] = Order();
+    PresetGroup *make_preset_group_(std::string g_name) {
+        auto g = get_group_(g_name);
+        if (g == nullptr) {
+            g = new PresetGroup(g_name);
+            if (first_group_ == nullptr) {
+                first_group_ = last_group_ = active_group_ = g;
+            } else {
+                last_group_->next_group = g;
+                last_group_ = g;
+            }
         }
-        if (map_[group].find(name) == map_[group].end()) {
-            map_[group][name] = new light::LightCall(_light);
-            preset_order_[group].push_back(name);
-        }
+        return g;
+    }
 
-        return map_[group][name];
+    PresetGroup *get_group_(std::string g_name) {
+        for (auto g = first_group_; g != nullptr; g = g->next_group) {
+            if (g->name == g_name) {
+                return g;
+            }
+        }
+        return nullptr;
+    }
+
+
+    light::LightCall *make_preset_call_(std::string g_name, std::string p_name) {
+        auto g = make_preset_group_(g_name);
+        auto p = g->make_preset(p_name);
+        auto c = new light::LightCall(_light);
+        p->set_light_call(c);
+        return c;
     }
 };
 

--- a/sensor/slider_sensor.h
+++ b/sensor/slider_sensor.h
@@ -48,7 +48,7 @@ public:
     }
 
     void dump_config() {
-        ESP_LOGCONFIG(TAG, "Front Panel slider sensor:");
+        ESP_LOGCONFIG(TAG, "Front panel slider sensor:");
         ESP_LOGCONFIG(TAG, "  Range from: %f", range_from_);
         ESP_LOGCONFIG(TAG, "  Range to: %f", range_to_);
     }


### PR DESCRIPTION
# Implements: https://github.com/mmakaay/esphome-xiaomi_bslamp2/issues/8 : [FEATURE] Implement presets support

Support for presets was added. This comprises of two parts:

* Defining presets
* Activating presets from automations

**Defining presets**

Presets can be added to the light component definition for the Xiaomi Bedside Lamp 2.
Presets are arranged in groups (of which you can create as many as you like).
Here's an example:

```yaml

light:
  - platform: xiaomi_bslamp2
    effects:
      - random:
          name: "Fast Random"
          transition_length: 3s
          update_interval: 3s
    presets:
      rgb:
        red:         { red: 100%, green: 0%,   blue: 0%   }
        green:       { red: 0%,   green: 100%, blue: 0%   }
        blue:        { red: 0%,   green: 0%,   blue: 100% }
        yellow:      { red: 100%, green: 100%, blue: 0%   }
        purple:      { red: 100%, green: 0%,   blue: 100% }
        randomize:   { effect: Fast Random                }
      white:
        cold:        { color_temperature: 153 mireds      }
        chilly:      { color_temperature: 275 mireds      }
        luke:        { color_temperature: 400 mireds      }
        warm:        { color_temperature: 588 mireds      }
```

In the above example, I created two groups: "rgb" and "white". 
Note that you can create any grouping that you like. This grouping was mainly created to be in line with the original firmware, in which one can switch between RGB presets and color temperature-based presets.
So, if you want to created a single preset group, which contains a mix of RGB and color temperature light presents, then go ahead!

A preset can define one of the following light types:

* RGB
  * mandatory keys: `red`, `green`, `blue`
  * optional keys: `transition_length`, `brightness`
* Color Temperature
  * mandatory key: `color_temperature`
  * optional keys: `transition_length`, `brightness`
* Effect
  * mandatory key: `effect`

**Activating presets from automations**

The automation action `preset.activate` can be used to activate a preset.
The following options are possible:

```yaml
# Activate the next preset group.
# The first available preset from the group is activated, or the last known
# preset if the group was activated before.
# After the last available preset group, the system will jump back to the first one.
preset.activate:
  next: group

# Activate the next preset within the currently active preset group.
# After the last available preset, the system will jump back to the first one.
preset.activate:
  next: preset

# Activate a specific preset group by specifying the group's name.
# The first available preset from the group is activated, or the last known
# preset if the group was activated before.
preset.activate:
  group: rgb

# Activate a specific preset by specifying both the preset's name and its group's name.
preset.activate:
  group: white
  preset: warm
```

Shortcut definitions are available for all these actions:

```yaml
preset.activate: next_group

preset.activate: next_preset

preset.activate: rgb

preset.activate: white.warm
```

**Handling of invalid input**

When a group or template is specified that does not exist, or if next group/preset is used while no presets have been defined at all, then the action will be ignored and an error will be logged.
A remaining development task is to detect invalid group and preset names during code generation.

** Full example?**

A full example configuration can be found in the repository under `doc/example.yaml`.
This example shows how to mimic the behavior of the original firmware.
Tap the color button to switch to the next preset, hold the color button to switch between RGB and color temperature light.