### PR TITLE
Better front panel HAL that allows controlling the individual LEDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Note**: This release requires ESPHome v1.19.0 or newer.
 
+### Added
+- It is now possible to address the LEDs in the front panel of the device individually.
+  There are 12 LEDs in total: the power button, the color button and 10 LEDs that are
+  used by the original firmware to represent the lamp's current brightness setting.
+  The `output` component for the lamp was updated to provide access to the individual LEDs. 
+  Check out the [documentation guide](https://github.com/mmakaay/esphome-xiaomi_bslamp2/blob/main/doc/configuration.md) 
+  for details on how to control the individual LEDs.
+
 ### Changed
 - Made it possible to use lambdas with the `preset.activate` automation. This makes it
   possible to link the action to an api service, which exposes the preset functionality

--- a/README.md
+++ b/README.md
@@ -30,11 +30,16 @@ aspect of the lamp and to integrate the lamp in your Home Assistant setup.
   light mode is missing in the Home Assistant GUI.
 
 * **Since the components of the lamp are exposed as ESPHome components, you don't have to stick with
-  the lamp's original behavior**. You can hook up the lamp in your home automation as you see fit.
+  the lamp's original behavior.** You can hook up the lamp in your home automation as you see fit.
   Use the slider to control the volume of your audio set? Long press the power button to put your
   house in night mode? Use the illumination behind the slider bar to represent the progress of your
   sour dough bread bulk fermentation?  Go ahead, make it so! :-)
- 
+
+* **All LEDs that are used for illumination of the front panel (power button, color button and
+  10 LEDs for the brightness slider) can be controlled individually.** This means that you have
+  12 LEDs in total to use as you see fit, instead of sticking with the behavior of the original
+  firmware.
+
 * **Possibilities to extend the device's functionality through hardware mods.** There are [GPIO pins
   that are not in use](doc/technical_details.md#esp32-pinout).  If "tinkerer" is your middle name,
   you can use those pins to come up with your own hardware hacks to extend the device's
@@ -60,7 +65,7 @@ For those who have experience with flashing ESPHome onto devices:
 
 * [Why custom firmware?](doc/why_custom_firmware.md)
 * [Installation guide](doc/installation.md)
-* [Configuration_guide](doc/configuration.md)
+* [Configuration guide](doc/configuration.md)
 * [Flashing guide](doc/flashing.md)
 * [Technical details](doc/technical_details.md)
 * [Sponsoring](doc/sponsoring.md)

--- a/components/xiaomi_bslamp2/__init__.py
+++ b/components/xiaomi_bslamp2/__init__.py
@@ -13,7 +13,6 @@ from esphome.const import (
 
 CODEOWNERS = ["@mmakaay"]
 
-CONF_HUB_ID = "xiaomi_bslamp2_hub_id"
 CONF_RED_ID = "red_id"
 CONF_GREEN_ID = "green_id"
 CONF_BLUE_ID = "blue_id"
@@ -25,8 +24,8 @@ CONF_MASTER2_ID = "master2_id"
 CONF_FP_I2C_ID = "front_panel_i2c_id"
 CONF_LIGHT_HAL_ID = "light_hal_id"
 CONF_FRONT_PANEL_HAL_ID = "front_panel_hal_id"
-
 CONF_ON_BRIGHTNESS = "on_brightness"
+CONF_LEDS = "leds"
 
 AUTO_LOAD = ["ledc", "output", "i2c"]
 

--- a/components/xiaomi_bslamp2/__init__.py
+++ b/components/xiaomi_bslamp2/__init__.py
@@ -34,6 +34,23 @@ bslamp2_ns = xiaomi_ns.namespace("bslamp2")
 LightHAL = bslamp2_ns.class_("LightHAL", cg.Component)
 FrontPanelHAL = bslamp2_ns.class_("FrontPanelHAL", cg.Component, I2CDevice)
 
+FrontPanelLEDs = bslamp2_ns.enum("FrontPanelLEDs")
+FRONT_PANEL_LED_OPTIONS = {
+    "NONE": FrontPanelLEDs.LED_NONE,
+    "POWER": FrontPanelLEDs.LED_POWER,
+    "COLOR": FrontPanelLEDs.LED_COLOR,
+    "1": FrontPanelLEDs.LED_1,
+    "2": FrontPanelLEDs.LED_2,
+    "3": FrontPanelLEDs.LED_3,
+    "4": FrontPanelLEDs.LED_4,
+    "5": FrontPanelLEDs.LED_5,
+    "6": FrontPanelLEDs.LED_6,
+    "7": FrontPanelLEDs.LED_7,
+    "8": FrontPanelLEDs.LED_8,
+    "9": FrontPanelLEDs.LED_9,
+    "10": FrontPanelLEDs.LED_10,
+}
+
 CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend({
     # RGBWW Light
     cv.GenerateID(CONF_LIGHT_HAL_ID): cv.declare_id(LightHAL),

--- a/components/xiaomi_bslamp2/__init__.py
+++ b/components/xiaomi_bslamp2/__init__.py
@@ -37,6 +37,7 @@ FrontPanelHAL = bslamp2_ns.class_("FrontPanelHAL", cg.Component, I2CDevice)
 FrontPanelLEDs = bslamp2_ns.enum("FrontPanelLEDs")
 FRONT_PANEL_LED_OPTIONS = {
     "NONE": FrontPanelLEDs.LED_NONE,
+    "ALL": FrontPanelLEDs.LED_ALL,
     "POWER": FrontPanelLEDs.LED_POWER,
     "COLOR": FrontPanelLEDs.LED_COLOR,
     "1": FrontPanelLEDs.LED_1,

--- a/components/xiaomi_bslamp2/binary_sensor/__init__.py
+++ b/components/xiaomi_bslamp2/binary_sensor/__init__.py
@@ -33,6 +33,7 @@ def validate_binary_sensor(conf):
     if CONF_PART in conf and CONF_FOR in conf:
         raise cv.Invalid("Specify only one of [part] or [for]")
     if CONF_PART in conf and not CONF_FOR in conf:
+        # Backward compatibility.
         conf[CONF_FOR] = conf[CONF_PART]
     if CONF_FOR not in conf:
         raise cv.Invalid("'for' is a required option for [binary_sensor.xiaomi_bslamp2]")

--- a/components/xiaomi_bslamp2/front_panel_hal.h
+++ b/components/xiaomi_bslamp2/front_panel_hal.h
@@ -22,9 +22,9 @@ using EVENT = uint16_t;
 // LED_1 is the slider LED closest to the power button.
 // LED_10 is the one closest to the color button.
 enum FrontPanelLEDs {
-  LED_ALL   = 32768 + 8192 + 1023,
-  LED_POWER = 32768,
-  LED_COLOR = 8192,
+  LED_ALL   = 16384 + 4096 + 1023,
+  LED_POWER = 16384,
+  LED_COLOR = 4096,
   LED_1     = 512,
   LED_2     = 256,
   LED_3     = 128,

--- a/components/xiaomi_bslamp2/front_panel_hal.h
+++ b/components/xiaomi_bslamp2/front_panel_hal.h
@@ -13,43 +13,42 @@ namespace bslamp2 {
 static const uint8_t MSG_LEN = 7;
 using MSG = uint8_t[MSG_LEN];
 using LED = uint16_t;
+using EVENT = uint16_t;
 
 // clang-format off
 
-// Bit patterns that are used for making a front panel LED light up.
-// These patterns can be bitwise OR-ed to target multiple LEDs.
-static const LED LED_NONE        = 0b0000110000000000;
-static const LED LED_POWER       = 0b0100110000000000;
-static const LED LED_COLOR       = 0b0001110000000000;
-static const LED LED_1           = 0b0000111000000000;
-static const LED LED_2           = 0b0000110100000000;
-static const LED LED_3           = 0b0000110010000000;
-static const LED LED_4           = 0b0000110001000000;
-static const LED LED_5           = 0b0000110000100000;
-static const LED LED_6           = 0b0000110000010000;
-static const LED LED_7           = 0b0000110000001000;
-static const LED LED_8           = 0b0000110000000100;
-static const LED LED_9           = 0b0000110000000010;
-static const LED LED_10          = 0b0000110000000001;
+enum FrontPanelLeds {
+  LED_NONE  = 0,
+  LED_POWER = 1 << 14,
+  LED_COLOR = 1 << 12,
+  LED_1     = 1 << 9,
+  LED_2     = 1 << 8,
+  LED_3     = 1 << 7,
+  LED_4     = 1 << 6,
+  LED_5     = 1 << 5,
+  LED_6     = 1 << 4,
+  LED_7     = 1 << 3,
+  LED_8     = 1 << 2,
+  LED_9     = 1 << 1,
+  LED_10    = 1,
+};
 
 // Combinations of LEDs that are use by the original firmware to
 // indicate the current brightness setting of the lamp..
-static const LED LED_LEVEL_0     = LED_NONE;
-static const LED LED_LEVEL_1     = LED_POWER|LED_COLOR|LED_1;
-static const LED LED_LEVEL_2     = LED_POWER|LED_COLOR|LED_1|LED_2;
-static const LED LED_LEVEL_3     = LED_POWER|LED_COLOR|LED_1|LED_2|LED_3;
-static const LED LED_LEVEL_4     = LED_POWER|LED_COLOR|LED_1|LED_2|LED_3|LED_4;
-static const LED LED_LEVEL_5     = LED_POWER|LED_COLOR|LED_1|LED_2|LED_3|LED_4|LED_5;
-static const LED LED_LEVEL_6     = LED_POWER|LED_COLOR|LED_1|LED_2|LED_3|LED_4|LED_5|LED_6;
-static const LED LED_LEVEL_7     = LED_POWER|LED_COLOR|LED_1|LED_2|LED_3|LED_4|LED_5|LED_6|LED_7;
-static const LED LED_LEVEL_8     = LED_POWER|LED_COLOR|LED_1|LED_2|LED_3|LED_4|LED_5|LED_6|LED_7|LED_8;
-static const LED LED_LEVEL_9     = LED_POWER|LED_COLOR|LED_1|LED_2|LED_3|LED_4|LED_5|LED_6|LED_7|LED_8|LED_9;
-static const LED LED_LEVEL_10    = LED_POWER|LED_COLOR|LED_1|LED_2|LED_3|LED_4|LED_5|LED_6|LED_7|LED_8|LED_9|LED_10;
+static const LED LED_LEVEL_0  = LED_NONE;
+static const LED LED_LEVEL_1  = LED_POWER | LED_COLOR | LED_1;
+static const LED LED_LEVEL_2  = LED_LEVEL_1 | LED_2;
+static const LED LED_LEVEL_3  = LED_LEVEL_2 | LED_3;
+static const LED LED_LEVEL_4  = LED_LEVEL_3 | LED_4;
+static const LED LED_LEVEL_5  = LED_LEVEL_4 | LED_5;
+static const LED LED_LEVEL_6  = LED_LEVEL_5 | LED_6;
+static const LED LED_LEVEL_7  = LED_LEVEL_6 | LED_7;
+static const LED LED_LEVEL_8  = LED_LEVEL_7 | LED_8;
+static const LED LED_LEVEL_9  = LED_LEVEL_8 | LED_9;
+static const LED LED_LEVEL_10 = LED_LEVEL_9 | LED_10;
 
-// Commands for the I2C interface.
+// This I2C command is used during front panel event handling.
 static const MSG READY_FOR_EV = {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
-
-using EVENT = uint16_t;
 
 // Bit flags that are used for specifying an event.
 // Events are registered using the following bit pattern

--- a/components/xiaomi_bslamp2/output/__init__.py
+++ b/components/xiaomi_bslamp2/output/__init__.py
@@ -2,19 +2,21 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import output
 from esphome.const import CONF_ID
+from esphome import automation
 from .. import (
     bslamp2_ns, CODEOWNERS,
-    CONF_FRONT_PANEL_HAL_ID, FrontPanelHAL
+    CONF_FRONT_PANEL_HAL_ID, FrontPanelHAL, CONF_LEDS
 )
 
 AUTO_LOAD = ["xiaomi_bslamp2"]
 
-XiaomiBslamp2FrontPanelLight = bslamp2_ns.class_(
-    "XiaomiBslamp2FrontPanelLight", output.FloatOutput, cg.Component)
+XiaomiBslamp2FrontPanelOutput = bslamp2_ns.class_(
+    "XiaomiBslamp2FrontPanelOutput", output.FloatOutput, cg.Component)
+SetLEDsAction = bslamp2_ns.class_("SetLEDsAction", automation.Action)
 
 CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
-        cv.GenerateID(): cv.declare_id(XiaomiBslamp2FrontPanelLight),
+        cv.GenerateID(): cv.declare_id(XiaomiBslamp2FrontPanelOutput),
         cv.GenerateID(CONF_FRONT_PANEL_HAL_ID): cv.use_id(FrontPanelHAL),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -26,3 +28,28 @@ def to_code(config):
 
     front_panel_hal_var = yield cg.get_variable(config[CONF_FRONT_PANEL_HAL_ID])
     cg.add(var.set_parent(front_panel_hal_var))
+
+
+def maybe_simple_leds_value(schema):
+    def validator(value):
+        if isinstance(value, dict):
+            return schema(value)
+        return schema({ "leds": value })
+    return validator
+
+@automation.register_action(
+    "output.set_leds",
+    SetLEDsAction,
+    cv.Schema(
+        maybe_simple_leds_value(cv.Schema({
+            cv.GenerateID(CONF_ID): cv.use_id(XiaomiBslamp2FrontPanelOutput),
+            cv.Required(CONF_LEDS): cv.templatable(cv.uint16_t),
+        }))
+    )
+)
+async def set_leds_to_code(config, action_id, template_arg, args):
+    output_var = await cg.get_variable(config[CONF_ID]) 
+    var = cg.new_Pvariable(action_id, template_arg, output_var)
+    template_ = await cg.templatable(config[CONF_LEDS], args, cg.uint16)
+    cg.add(var.set_leds(template_))
+    return var

--- a/components/xiaomi_bslamp2/output/__init__.py
+++ b/components/xiaomi_bslamp2/output/__init__.py
@@ -14,6 +14,7 @@ AUTO_LOAD = ["xiaomi_bslamp2"]
 XiaomiBslamp2FrontPanelOutput = bslamp2_ns.class_(
     "XiaomiBslamp2FrontPanelOutput", output.FloatOutput, cg.Component)
 SetLEDsAction = bslamp2_ns.class_("SetLEDsAction", automation.Action)
+UpdateLEDsAction = bslamp2_ns.class_("UpdateLEDsAction", automation.Action)
 
 CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
@@ -36,6 +37,10 @@ def maybe_simple_leds_value(schema):
             return schema(value)
         return schema({ "leds": value })
     return validator
+
+FRONT_PANEL_SCHEMA = cv.Schema({
+    cv.GenerateID(CONF_ID): cv.use_id(XiaomiBslamp2FrontPanelOutput),
+})
 
 FRONT_PANEL_LED_SCHEMA = cv.Schema(
     maybe_simple_leds_value(cv.Schema({
@@ -81,4 +86,10 @@ async def turn_off_leds_to_code(config, action_id, template_arg, args):
     value = cg.RawExpression("|".join(map(str, bits)))
     cg.add(action_var.set_mode(0))
     cg.add(action_var.set_leds(value))
+    return action_var
+
+@automation.register_action("front_panel.update_leds", UpdateLEDsAction, FRONT_PANEL_SCHEMA)
+async def update_leds_to_code(config, action_id, template_arg, args):
+    output_var = await cg.get_variable(config[CONF_ID]) 
+    action_var = cg.new_Pvariable(action_id, template_arg, output_var)
     return action_var

--- a/components/xiaomi_bslamp2/output/automation.h
+++ b/components/xiaomi_bslamp2/output/automation.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
+#include "../front_panel_hal.h"
 #include "output.h"
 #include <cmath>
 
@@ -13,11 +14,23 @@ template<typename... Ts> class SetLEDsAction : public Action<Ts...> {
  public:
   explicit SetLEDsAction(XiaomiBslamp2FrontPanelOutput *parent) : parent_(parent) {}
 
+  TEMPLATABLE_VALUE(int, mode)
   TEMPLATABLE_VALUE(uint16_t, leds)
 
   void play(Ts... x) override {
+    uint16_t mode = this->mode_.value(x...);
     uint16_t value = this->leds_.value(x...);
-    parent_->set_leds(value);
+    switch (mode) {
+      case 0:
+        parent_->turn_off_leds(value);
+        break;
+      case 1:
+        parent_->turn_on_leds(value);
+        break;
+      case 2:
+        parent_->set_leds(value);
+        break;
+    }
   }
 
  protected:

--- a/components/xiaomi_bslamp2/output/automation.h
+++ b/components/xiaomi_bslamp2/output/automation.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "output.h"
+#include <cmath>
+
+namespace esphome {
+namespace xiaomi {
+namespace bslamp2 {
+
+template<typename... Ts> class SetLEDsAction : public Action<Ts...> {
+ public:
+  explicit SetLEDsAction(XiaomiBslamp2FrontPanelOutput *parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(uint16_t, leds)
+
+  void play(Ts... x) override {
+    uint16_t value = this->leds_.value(x...);
+    parent_->set_leds(value);
+  }
+
+ protected:
+  XiaomiBslamp2FrontPanelOutput *parent_;
+};
+
+}  // namespace bslamp2
+}  // namespace xiaomi
+}  // namespace esphome

--- a/components/xiaomi_bslamp2/output/automation.h
+++ b/components/xiaomi_bslamp2/output/automation.h
@@ -37,6 +37,18 @@ template<typename... Ts> class SetLEDsAction : public Action<Ts...> {
   XiaomiBslamp2FrontPanelOutput *parent_;
 };
 
+template<typename... Ts> class UpdateLEDsAction : public Action<Ts...> {
+ public:
+  explicit UpdateLEDsAction(XiaomiBslamp2FrontPanelOutput *parent) : parent_(parent) {}
+
+  void play(Ts... x) override {
+    parent_->update_leds();
+  }
+
+ protected:
+  XiaomiBslamp2FrontPanelOutput *parent_;
+};
+
 }  // namespace bslamp2
 }  // namespace xiaomi
 }  // namespace esphome

--- a/components/xiaomi_bslamp2/output/output.h
+++ b/components/xiaomi_bslamp2/output/output.h
@@ -35,6 +35,10 @@ class XiaomiBslamp2FrontPanelOutput : public output::FloatOutput, public Compone
     front_panel_->turn_off_leds(leds);
   }
 
+  void update_leds() {
+    front_panel_->update_leds();
+  }
+
  protected:
   FrontPanelHAL *front_panel_;
 };

--- a/components/xiaomi_bslamp2/output/output.h
+++ b/components/xiaomi_bslamp2/output/output.h
@@ -13,11 +13,19 @@ namespace bslamp2 {
  * An output, used for controlling the front panel illumination and
  * level indicator on the Xiaomi Mijia Bedside Lamp 2 front panel.
  */
-class XiaomiBslamp2FrontPanelLight : public output::FloatOutput, public Component {
+class XiaomiBslamp2FrontPanelOutput : public output::FloatOutput, public Component {
  public:
-  void set_parent(FrontPanelHAL *front_panel) { front_panel_ = front_panel; }
+  void set_parent(FrontPanelHAL *front_panel) {
+    front_panel_ = front_panel;
+  }
 
-  void write_state(float level) { front_panel_->set_light_level(level); }
+  void write_state(float level) {
+    front_panel_->set_light_level(level);
+  }
+
+  void set_leds(uint16_t leds) {
+    front_panel_->set_leds(leds);
+  }
 
  protected:
   FrontPanelHAL *front_panel_;

--- a/components/xiaomi_bslamp2/output/output.h
+++ b/components/xiaomi_bslamp2/output/output.h
@@ -27,6 +27,14 @@ class XiaomiBslamp2FrontPanelOutput : public output::FloatOutput, public Compone
     front_panel_->set_leds(leds);
   }
 
+  void turn_on_leds(uint16_t leds) {
+    front_panel_->turn_on_leds(leds);
+  }
+
+  void turn_off_leds(uint16_t leds) {
+    front_panel_->turn_off_leds(leds);
+  }
+
  protected:
   FrontPanelHAL *front_panel_;
 };

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -417,7 +417,7 @@ This can also be written as:
         - front_panel.set_leds: [ POWER, COLOR, 1, 2, 3 ]
 ```
 
-If only one LED is specified, you are allowed to omit the list;
+If only one LED is specified, you are allowed to omit the list definition:
 
 ```yaml
     on_...:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -129,7 +129,7 @@ It is possible to control the night light mode separately. An example of this ca
 [example.yaml](../example.yaml), in which holding the power button is bound to activating the night
 light.
 
-### light.disco_on Action
+### `light.disco_on` Action
 
 This action sets the state of the light immediately (i.e. without waiting for the next main loop
 iteration), without saving the state to memory and without publishing the state change.
@@ -148,7 +148,7 @@ on_...:
 The possible configuration options for this Action are the same as those for the standard
 `light.turn_on` Action.
 
-### light.disco_off Action
+### `light.disco_off` Action
 
 This action turns off the disco mode by restoring the state of the lamp to the last known state from
 before using the disco mode.
@@ -198,7 +198,7 @@ light:
     ..
 ```
 
-*Note: duplicate template names are ok, as long as they are within their own group. If you use
+*Note: Duplicate template names are ok, as long as they are within their own group. If you use
 duplicate preset names within a single group, then the last preset will override the earlier
 one(s).*
 
@@ -348,8 +348,9 @@ sensor:
 ## Component: output
 
 The (float) output component is linked to the front panel illumination + level indicator. Setting
-this output to value 0.0 will turn off the frontpanel illumination. Other values, up to 1.0, will
-turn on the illumination and will set the level indicator to the requested level (in 10 steps).
+this output (using the standard `output.set_level` action) to value 0.0 will turn off the frontpanel
+illumination. Other values, up to 1.0, will turn on the illumination and will set the level indicator
+to the requested level (in 10 steps).
 
 ```yaml
 output:
@@ -361,6 +362,97 @@ output:
 
 * **id** (**Required**, ID): The id to use for this output component.
 * All other options from [Output](https://esphome.io/components/output/index.html)
+
+### Addressing the LEDs of the illumination individually
+
+While the standard `output.set_level` action emulates the front panel illumination behavior
+of the original device firmware, it is also possible to control all of the LEDs for this
+illumination individually, in case you need some different behavior, e.g. leaving the
+power button on at night, so the user can easily find it in the dark.
+
+To address the LEDs, the following identifiers can be used in your YAML configuration:
+
+* `POWER` : The power button illumination.
+* `COLOR` : The color button illumination.
+* `1`, `2`, .., `10` : The 10 LEDs on the slider, where LED `1` is closest to the
+  power button and LED `10` is closest to the color button.
+* `ALL` : represents all of the available LEDs
+* `NONE` : represents none of the available LEDs
+
+#### `front_panel.set_leds` Action
+
+This action turns on the provided LEDs, all other LEDs are turned off.
+
+```yaml
+    on_...:
+      then:
+        - front_panel.set_leds:
+            leds:
+              - POWER
+              - COLOR
+              - 1
+              - 2
+              - 3
+```
+
+The `leds:` key can also be omitted here, making the following action calls
+equivalent to the one above.
+
+```yaml
+    on_...:
+      then:
+        - front_panel.set_leds:
+            - POWER
+            - COLOR
+            - 1
+            - 2
+            - 3
+```
+ 
+and
+
+```yaml
+    on_...:
+      then:
+        - front_panel.set_leds: [ POWER, COLOR, 1, 2, 3 ]
+```
+
+If only one let is specified, you can also omit the list;
+
+```yaml
+    on_...:
+      then:
+        - front_panel.set_leds: POWER
+```
+
+#### `front_panel.turn_on_leds` Action
+
+This action turns on the provided LEDs, and leaves the rest of the LEDs as-is.
+The LEDs to affect are specified in the same wat as above for `front_panel.set_leds`.
+
+#### `front_panel.turn_off_leds` Action
+
+This action turns off the provided LEDs, and leaves the rest of the LEDs as-is.
+The LEDs to affect are specified in the same wat as above for `front_panel.set_leds`.
+
+#### `front_panel.update_leds` Action
+
+The previous actions only modify the required state for the front panel LEDs.
+Updating the actual state of the LEDs is done when the main loop for the
+output component is run by ESPHome.
+
+If you need the required state to be pushed to the LEDs immediately, regardless
+the main loop, then this action can ben used to take care of this.
+
+*Note: In most situations, you will not need to use this action explicitly
+to make the LEDs update. Only use it when you are sure that this is required.*
+
+```yaml
+    on_...:
+      then:
+        - front_panel.set_leds: POWER
+        - front_panel.update_leds:
+```
 
 ## Component: text_sensor
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -409,7 +409,7 @@ equivalent to the one above.
             - 3
 ```
  
-and
+This can also be written as:
 
 ```yaml
     on_...:
@@ -417,7 +417,7 @@ and
         - front_panel.set_leds: [ POWER, COLOR, 1, 2, 3 ]
 ```
 
-If only one let is specified, you can also omit the list;
+If only one LED is specified, you are allowed to omit the list;
 
 ```yaml
     on_...:

--- a/doc/technical_details.md
+++ b/doc/technical_details.md
@@ -149,7 +149,7 @@ connector on the main board, including the functions of the cable pins:
 
 Commands can be written to the front panel at any time.
 
-The available commands are:
+The commands that are used by the original firmware are these:
 
 | Command         | Byte sequence to send |
 |-----------------|-----------------------|
@@ -169,6 +169,29 @@ The available commands are:
 
 *Note: The `READY FOR EVENT` command is only used when a new event is provided by the front panel.
 Information about this command can be found in the next section.*
+
+Further experimentation has uncovered that the LEDs of the front panel (power, color, level 1 - 10)
+can be enabled individually. The original firmware does not use this, but I built support for it
+into the custom firmware, because it opens up some nice possibilities.
+
+How this works, is that the general format of the "set LEDs" command is: `02 03 XX XX 64 00 00`.
+The LEDs to enable are specified using the `XX XX` part. This is a 16 bit value, which can be
+constructed by bitwise OR-ing the following LED bit values:
+
+| LED to enable | Bit pattern       |
+|---------------|-------------------|
+| POWER         | 01001100 00000000 |
+| COLOR         | 00011100 00000000 |
+| LED 1         | 00001110 00000000 |
+| LED 2         | 00001101 00000000 |
+| LED 3         | 00001100 10000000 |
+| LED 4         | 00001100 01000000 |
+| LED 5         | 00001100 00100000 |
+| LED 6         | 00001100 00010000 |
+| LED 7         | 00001100 00001000 |
+| LED 8         | 00001100 00000100 |
+| LED 9         | 00001100 00000010 |
+| LED 10        | 00001100 00000001 |
 
 **Reading events from the front panel**
 

--- a/doc/technical_details.md
+++ b/doc/technical_details.md
@@ -170,8 +170,8 @@ The commands that are used by the original firmware are these:
 *Note: The `READY FOR EVENT` command is only used when a new event is provided by the front panel.
 Information about this command can be found in the next section.*
 
-Further experimentation has uncovered that the LEDs of the front panel (power, color, level 1 - 10)
-can be enabled individually. The original firmware does not use this, but I built support for it
+Further experimentation has uncovered that the LEDs of the front panel can be controlled
+individually. The original firmware does not use this feature, but I built support for it
 into the custom firmware, because it opens up some nice possibilities.
 
 How this works, is that the general format of the "set LEDs" command is: `02 03 XX XX 64 00 00`.
@@ -192,6 +192,9 @@ constructed by bitwise OR-ing the following LED bit values:
 | LED 8         | 00001100 00000100 |
 | LED 9         | 00001100 00000010 |
 | LED 10        | 00001100 00000001 |
+
+LED 1 is the one closest to the power button.
+LED 10 is the one closest to the color button.
 
 **Reading events from the front panel**
 


### PR DESCRIPTION
Provides the support that is required for #38 (feature request to always leave the power button on, so it is visible at nght).
I did do some more reverse engineering and found a way to control the front panel LEDs individually. This PR implements new actions for the xiaomi_bslamp2 output component that allow for this.