### PR TITLE
Make code compile with both v1.20.* and v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0-RC1]
 
 **Note**: This release requires ESPHome v1.21.0 and Home Assistant 2021.8.0 or newer.
+The code will compile with ESPHome v1.20.0, but the lamp will not be controllable
+through the Home Assistant GUI when using Home Assistant 2021.8.0 or newer.
+Only turn on/off and brightness will be available.
 
 ### Changed
 - The code has been made compatible with the new color mode support in Home Assistant.

--- a/components/xiaomi_bslamp2/common.h
+++ b/components/xiaomi_bslamp2/common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "esphome/core/defines.h"
+
 namespace esphome {
 namespace xiaomi {
 namespace bslamp2 {

--- a/components/xiaomi_bslamp2/light/__init__.py
+++ b/components/xiaomi_bslamp2/light/__init__.py
@@ -213,6 +213,8 @@ def light_output_to_code(config):
     yield light.register_light(light_output_var, config)
     light_hal_var = yield cg.get_variable(config[CONF_LIGHT_HAL_ID])
     cg.add(light_output_var.set_parent(light_hal_var))
+    if hasattr(light, "types") and hasattr(light.types, "COLOR_MODES"):
+        cg.add_define('HAS_COLOR_MODES')
 
 @coroutine
 def on_brightness_to_code(config):

--- a/components/xiaomi_bslamp2/light/color_rgb_light.h
+++ b/components/xiaomi_bslamp2/light/color_rgb_light.h
@@ -252,9 +252,15 @@ class ColorRGBLight : public GPIOOutputs {
   bool set_light_color_values(light::LightColorValues v) {
     light_mode = LIGHT_MODE_RGB;
 
+#ifdef HAS_COLOR_MODES
     if (v.get_color_mode() != light::ColorMode::RGB) {
       return false;
     }
+#else
+    if (v.get_white() > 0.0f) {
+      return false;
+    }
+#endif
 
     // Determine the ring level for the color. This is a value between 0
     // and 7, determining in what ring of the RGB circle the requested

--- a/components/xiaomi_bslamp2/light/color_white_light.h
+++ b/components/xiaomi_bslamp2/light/color_white_light.h
@@ -80,9 +80,15 @@ class ColorWhiteLight : public GPIOOutputs {
   bool set_light_color_values(light::LightColorValues v) {
     light_mode = LIGHT_MODE_WHITE;
 
+#ifdef HAS_COLOR_MODES
     if (v.get_color_mode() != light::ColorMode::COLOR_TEMPERATURE) {
       return false;
     }
+#else
+    if (v.get_white() == 0.0f) {
+      return false;
+    }
+#endif
 
     auto temperature = clamp_temperature_(v.get_color_temperature());
     auto brightness = clamp_brightness_(v.get_brightness());

--- a/components/xiaomi_bslamp2/light/light_output.h
+++ b/components/xiaomi_bslamp2/light/light_output.h
@@ -28,7 +28,15 @@ class XiaomiBslamp2LightOutput : public Component, public light::LightOutput {
    */
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
+#ifdef HAS_COLOR_MODES
     traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE});
+#else
+    traits.set_supports_rgb(true);
+    traits.set_supports_color_temperature(true);
+    traits.set_supports_brightness(true);
+    traits.set_supports_rgb_white_value(false);
+    traits.set_supports_color_interlock(true);
+#endif
     traits.set_min_mireds(MIRED_MIN);
     traits.set_max_mireds(MIRED_MAX);
     return traits;


### PR DESCRIPTION
People run into issues with the main tree being incompatible with ESPHome v1.20.* (#45)
I updated the code to introduce a `define #HAS_COLOR_MODES`, which is used to let the codebase automatically switch between the old and the new color mode code.
