### PR TITLE
Allow the external_components source to be overridden

### DIFF
--- a/packages/core.yaml
+++ b/packages/core.yaml
@@ -4,6 +4,7 @@
 # --------------------------------------------------------------------------
 
 substitutions:
+  external_components_source: github://mmakaay/esphome-xiaomi_bslamp2@release/2026.5.0
   name: bedside-lamp
   friendly_name: Bedside Lamp
   light_name: RGBWW Light
@@ -35,12 +36,12 @@ esp32:
       ignore_efuse_custom_mac: true
       ignore_efuse_mac_crc: true
 
-# Retrieve the code for the xiaomi_bslamp2 platform from GitHub.
+# Where to retrieve the code for the xiaomi_bslamp2 platform from. Defaults to
+# GitHub; override the substitution to build from a local checkout instead, e.g.
+#   substitutions:
+#     external_components_source: components
 external_components:
-  - source:
-      type: git
-      url: https://github.com/mmakaay/esphome-xiaomi_bslamp2
-      ref: release/2026.5.0
+  - source: ${external_components_source}
     refresh: 60s
 
 # Disable the reboot timeout. By default, the lamp reboots after 15


### PR DESCRIPTION
packages/core.yaml hardcodes the GitHub source for the xiaomi_bslamp2 platform, so a configuration that vendors this project - as a git submodule, for example - still has to fetch the component over the network, and cannot build at all if GitHub is unreachable.

Putting the source behind a substitution keeps the GitHub default byte for byte, while letting a local checkout be used instead:

    substitutions:
      external_components_source: components

The three-key mapping becomes the equivalent github:// shorthand because a substitution can only stand in for a scalar. ESPHome expands that shorthand to exactly the same {type, url, ref}, so nothing changes for existing users.

This mirrors what syssi/esphome-yeelight-ceiling-light already does, where CI overrides the same substitution to validate against the working tree.